### PR TITLE
Add ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ ubuntu-latest, windows-latest, windows-2019, macos-latest ]
+        platform: [ ubuntu-22.04, ubuntu-latest, windows-latest, windows-2019, macos-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install zip
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ ubuntu-latest, windows-latest, windows-2019, macos-latest ]
+        platform: [ ubuntu-22.04,  ubuntu-latest, windows-latest, windows-2019, macos-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Download Go tip artifact
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ ubuntu-latest, windows-latest, windows-2019, macos-latest ]
+        platform: [ ubuntu-22.04,  ubuntu-latest, windows-latest, windows-2019, macos-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Download Go tip artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ ubuntu-latest, windows-latest, windows-2019, macos-latest ]
+        platform: [ ubuntu-22.04, ubuntu-latest, windows-latest, windows-2019, macos-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Download Go tip


### PR DESCRIPTION
This as it seems we need ubuntu-22.04 to run browser tests now that latest is 24.04 :( 