### PR TITLE
ci: stop using windows-2019 runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ ubuntu-22.04, ubuntu-latest, windows-latest, windows-2019, macos-latest ]
+        platform: [ ubuntu-22.04, ubuntu-latest, windows-latest, windows-2022, macos-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install zip
-        if: matrix.platform == 'windows-latest' || matrix.platform == 'windows-2019'
+        if: matrix.platform == 'windows-latest' || matrix.platform == 'windows-2022'
         run: powershell.exe -Command "choco install zip"
       - name: Remove the default Go installation
-        if: matrix.platform == 'windows-latest' || matrix.platform == 'windows-2019'
+        if: matrix.platform == 'windows-latest' || matrix.platform == 'windows-2022'
         shell: pwsh
         run: |
           $go_path = (Get-Command go).Source
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ ubuntu-22.04,  ubuntu-latest, windows-latest, windows-2019, macos-latest ]
+        platform: [ ubuntu-22.04,  ubuntu-latest, windows-latest, windows-2022, macos-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Download Go tip artifact
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ ubuntu-22.04,  ubuntu-latest, windows-latest, windows-2019, macos-latest ]
+        platform: [ ubuntu-22.04,  ubuntu-latest, windows-latest, windows-2022, macos-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Download Go tip artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ ubuntu-22.04, ubuntu-latest, windows-latest, windows-2019, macos-latest ]
+        platform: [ ubuntu-22.04, ubuntu-latest, windows-latest, windows-2022, macos-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Download Go tip


### PR DESCRIPTION
The windows-2019 runners are deprecated as of 2025-06-01 and will be fully unsupported by 2025-06-30. There will be multiple brown-outs over the course of this month which might affect builds and releases unless we remove those runners.

See https://github.com/actions/runner-images/issues/12045 for details.