### PR TITLE
chore: prepare workflows for get-vault-secrets v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
       - id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
         with:
+          export_env: false
           repo_secrets: |
             SLACK_WEBHOOK_URL=slack:SLACK_WEBHOOK_URL
       - name: Slack on failure
@@ -157,5 +158,5 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ fromJSON(steps.get-secrets.outputs.secrets).SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## What?
Opts the release workflow's `get-vault-secrets` usage into the upcoming v2 behavior: sets `export_env: false` and reads the secret from the step's `secrets` output via `fromJSON(...)` instead of `env.NAME`.

## Why?
v2 of `grafana/shared-workflows/actions/get-vault-secrets` will no longer auto-export retrieved secrets as environment variables. This change makes the workflow forward-compatible before v2 lands.